### PR TITLE
Publish as a user-scoped module?

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name":        "circuit-breaker-js",
+  "name":        "@wasyl/circuit-breaker-js",
   "description": "Hystrix-like circuit breaker for JavaScript.",
   "version":     "0.0.2",
   "license":     "MIT",
@@ -8,7 +8,7 @@
 
   "repository": {
     "type": "git",
-    "url":  "git@github.int.yammer.com:yammer/circuit-breaker-js.git"
+    "url":  "git@github.com/Schibsted-Tech-Polska/circuit-breaker-js"
   },
 
   "main": "circuit-breaker.js",


### PR DESCRIPTION
:wave: Hi, I'm here by way of `good-guy-http`.

I noticed that you rely on this git dependency in that project.  Would you be open to publishing this fork as a user-scoped module on npm so we can all get faster installs?